### PR TITLE
seperate discord role management and database management

### DIFF
--- a/DiscordJunkDrawer.App/Modules/RoleModule.cs
+++ b/DiscordJunkDrawer.App/Modules/RoleModule.cs
@@ -71,19 +71,21 @@ namespace DiscordJunkDrawer.App.Modules
             {
                 try
                 {
-                    var curGuild = await _guildRepository.GetAsync(guild => guild.Id == Context.Guild.Id);
                     var createdRole = await Context.Guild.CreateRoleAsync(roleName, GuildPermissions.None, null, false, null);
-
+                    await Context.Message.AddReactionAsync(new Emoji("✅"));
+                    
+                    var curGuild = await _guildRepository.GetAsync(guild => guild.Id == Context.Guild.Id);
                     DiscordRoleModel roleToAdd = new DiscordRoleModel()
                     {
                         Id = createdRole.Id,
                         Name = roleName,
                         ServerId = Context.Guild.Id
                     };
+                    
                     curGuild.Roles.Add(roleToAdd);
                     await _guildRepository.UpdateAsync(curGuild);
                     await _roleRepository.AddAsync(roleToAdd);
-                    await Context.Message.AddReactionAsync(new Emoji("✅"));
+                    await Context.Message.AddReactionAsync(new Emoji("🗄️"));
                     return;
                 }
                 catch
@@ -150,17 +152,19 @@ namespace DiscordJunkDrawer.App.Modules
                 {
                     try
                     {
+                        await requestedRole.DeleteAsync();
+                        await Context.Message.AddReactionAsync(new Emoji("✅"));
 
                         var roleToDelete = await _roleRepository.GetAsync(x => x.Name == roleName);
                         await _roleRepository.RemoveAsync(roleToDelete);
-                        await requestedRole.DeleteAsync();
-                        await Context.Message.AddReactionAsync(new Emoji("✅"));
+                        await Context.Message.AddReactionAsync(new Emoji("🗄️"));
                         return;
 
                     }
                     catch
                     {
                         await Context.Message.AddReactionAsync(new Emoji("❌"));
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
So currently discord management with database management of roles is mixed and its hard to tell which part exactly failed. 

This change allows discord role management functionality to continue working even if reading and writing to the database fails. 